### PR TITLE
Enemies now spawn in waves

### DIFF
--- a/TowerDefense/Prefabs/Bot_Large.tscn
+++ b/TowerDefense/Prefabs/Bot_Large.tscn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33f1657429f63020541c0f134197a1eba9787e23d1ec638ba3e52aa52b6bd4c5
-size 824162
+oid sha256:917737b65fda58fc204cb918ab173bd245bd94b69a3f09472b70bd09c7c18c7b
+size 824179

--- a/TowerDefense/Prefabs/Bot_Medium.tscn
+++ b/TowerDefense/Prefabs/Bot_Medium.tscn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:daa0856a576a1ccc8b5feb23486147ab6f865023d2c36f552541104345d688f8
-size 644733
+oid sha256:7c00d29e38a4450523ce429db9ee5aac681c3ac521675552fed0bc8a22f1c3e0
+size 644748

--- a/TowerDefense/Prefabs/Bot_Small.tscn
+++ b/TowerDefense/Prefabs/Bot_Small.tscn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55f57c5a16b46873efb2a25ae68eb6de203abc21fc280fed662d7adc867287a4
-size 438922
+oid sha256:b645de95ef21fb8c6f96958bbcd09fcda7baff266087bcbf0e500e6e09677b0f
+size 438937

--- a/TowerDefense/Scripts/buttonManager.gd
+++ b/TowerDefense/Scripts/buttonManager.gd
@@ -1,12 +1,13 @@
 extends Button
+
 export (PackedScene) var tower
 
-onready var spatial = get_node("/root/Spatial")
 onready var gs: GameState = get_node("/root/Spatial/GameState")
 onready var price_display : Label = get_node("Label")
+onready var spatial = get_node("/root/Spatial")
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
+
+func _ready() -> void:
 	connect("pressed", self, "stage_tower")
 	price_display.text = "Price: " + str(tower.instance().price)
 

--- a/TowerDefense/Scripts/cameraPan.gd
+++ b/TowerDefense/Scripts/cameraPan.gd
@@ -1,21 +1,21 @@
 extends Camera
 
-export var pan_speed: float
 export var border_top: float
 export var border_right: float
 export var border_bottom: float
 export var border_left: float
+export var MAX_ZOOM: float
+export var pan_speed: float
 
-var zoom: float
 var _target_zoom: float
+var zoom: float
 
 const MIN_ZOOM: float = 10.0
-export var MAX_ZOOM: float
 const ZOOM_INCREMENT: float = 0.5
 const ZOOM_RATE: float = 8.0
 
 
-func _ready():
+func _ready() -> void:
 	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
 	zoom = global_transform.origin.y
 	_target_zoom = zoom
@@ -37,7 +37,6 @@ func _unhandled_input(event: InputEvent) -> void:
 			new_transform.z = max(new_transform.z, border_bottom)
 			new_transform.z = min(new_transform.z, border_top)
 			global_transform.origin = new_transform 
-	# Prevents errors when other keys are pressed.
 	if event is InputEventMouse:
 		if event.is_pressed():
 			if event.button_index == BUTTON_WHEEL_UP:
@@ -45,11 +44,12 @@ func _unhandled_input(event: InputEvent) -> void:
 			if event.button_index == BUTTON_WHEEL_DOWN:
 				zoom_out()
 
+
 func zoom_in() -> void:
 	_target_zoom = max(_target_zoom - ZOOM_INCREMENT, MIN_ZOOM)
 	set_physics_process(true)
 
 
-func zoom_out():
+func zoom_out() -> void:
 	_target_zoom = min(_target_zoom + ZOOM_INCREMENT, MAX_ZOOM)
 	set_physics_process(true)

--- a/TowerDefense/Scripts/enemyManager.gd
+++ b/TowerDefense/Scripts/enemyManager.gd
@@ -1,8 +1,11 @@
+class_name EnemyManager
+
 extends KinematicBody
 
 export var speed: float
 export var max_health: int
 export var reward: int
+export var spawn_cost: int
 
 enum { DAMAGED, WALK, DIE, COMPLETE }
 var current_health: int
@@ -50,18 +53,27 @@ func calc_path():
 				else:
 					# TODO: Deal damage to lives based on health.
 					gs.lose_lives(current_health)
-					queue_free()
+#					queue_free()
+					get_parent().remove_child(self)
+					
 			calc_patrol_path()
 
 
 func calc_patrol_path():
-	path = nav.get_simple_path(global_transform.origin, way_points[way_point_index].global_transform.origin, true)
-	path_node = 0
+	if self.is_inside_tree():
+		path = nav.get_simple_path(global_transform.origin, way_points[way_point_index].global_transform.origin, true)
+		path_node = 0
 
 
 func get_current_health() -> int:
 	return current_health
 
 
-func take_damage(var damage: int) -> void:
+func take_damage(var killer : Tower, var damage: int) -> void:
 	current_health -= damage
+	if current_health <= 0 and self.is_inside_tree():
+		killer.kill_count += 1
+		killer.current_target = null
+		gs.add_currency(reward)
+		get_parent().remove_child(self)
+		

--- a/TowerDefense/Scripts/enemyManager.gd
+++ b/TowerDefense/Scripts/enemyManager.gd
@@ -15,27 +15,27 @@ var current_state = WALK
 var way_points: Array
 var way_point_index: int = 0
 
-onready var nav = get_node("/root/Spatial/Navigation")
 onready var gs: GameState = get_node("/root/Spatial/GameState")
+onready var nav = get_node("/root/Spatial/Navigation")
 onready var waypoints_node = get_node("/root/Spatial/WayPoints")
 
 
-func _ready():
+func _ready() -> void:
 	current_health = max_health
 	create_path_array()
 	calc_patrol_path()
 
-func _physics_process(delta):
+
+func _physics_process(_delta) -> void:
 	calc_path()
 
 
-func create_path_array():
-	#way_points = [wp_01, wp_02, wp_03, wp_04]
+func create_path_array() -> void:
 	for c in waypoints_node.get_children():
 		way_points.append(c)
 
 
-func calc_path():
+func calc_path() -> void:
 	var distance_to_wp = way_points[way_point_index].global_transform.origin - global_transform.origin
 	if path_node < path.size():
 		var direction = path[path_node] - global_transform.origin
@@ -43,7 +43,6 @@ func calc_path():
 			path_node += 1
 		else:
 			move_and_slide(direction.normalized() * speed, Vector3.UP)
-			#var look_at_position = Vector3(path[path_node].x, 0, path[path_node].z)
 			look_at(path[path_node], Vector3.UP)
 			# If the enemy gets to the way point, point them to the next one.
 			if distance_to_wp.length() < 2:
@@ -51,15 +50,12 @@ func calc_path():
 					way_point_index += 1
 				# If there are no more waypoints, they got to the end, so destroy them.
 				else:
-					# TODO: Deal damage to lives based on health.
 					gs.lose_lives(current_health)
-#					queue_free()
 					get_parent().remove_child(self)
-					
 			calc_patrol_path()
 
 
-func calc_patrol_path():
+func calc_patrol_path() -> void:
 	if self.is_inside_tree():
 		path = nav.get_simple_path(global_transform.origin, way_points[way_point_index].global_transform.origin, true)
 		path_node = 0
@@ -76,4 +72,3 @@ func take_damage(var killer : Tower, var damage: int) -> void:
 		killer.current_target = null
 		gs.add_currency(reward)
 		get_parent().remove_child(self)
-		

--- a/TowerDefense/Scripts/enemySpawner.gd
+++ b/TowerDefense/Scripts/enemySpawner.gd
@@ -1,28 +1,26 @@
 extends Spatial
 
 export (Array, PackedScene) var enemies
-export var value_multiplier: int
 export var max_wave: int
+export var value_multiplier: int
 export var wave_duration: float
 export var wave_interval: float
-enum State {SPAWNING, WAITING, COUNTING, WIN, LOSE}
+
+enum State {SPAWNING, WAITING, COUNTING, WIN}
 var current_wave: int = 0
+var rng = RandomNumberGenerator.new()
+var spawn_interval: float
+var spawn_state = State.COUNTING
+var spawn_timer: float
+var wave: Array
+var wave_timer: float = 0
 var wave_value: int
 
-var spawn_interval: float
-
-var wave: Array
-
-var spawn_timer: float
-var wave_timer: float = 0
-var rng = RandomNumberGenerator.new()
-var spawn_state = State.COUNTING
-
-
 onready var enemy_node = get_node("/root/Spatial/Enemies")
+onready var gs: GameState = get_node("/root/Spatial/GameState")
 
 
-func _physics_process(delta):
+func _physics_process(delta) -> void:
 	match spawn_state:
 		State.SPAWNING:
 			if spawn_timer <= 0 and wave.size() > 0:
@@ -44,44 +42,26 @@ func _physics_process(delta):
 			if wave_timer <= 0:
 				spawn_state = State.SPAWNING
 				current_wave += 1
+				gs.set_wave(current_wave)
 				generate_wave()
 				spawn_timer = spawn_interval
 		State.WIN:
-			print("You won!")
-#	if spawn_state == State.SPAWNING:
-#		if spawn_timer <= 0 and wave.size() > 0:
-#			spawn_enemy()
-#		elif wave.size() == 0:
-#			spawn_state = State.WAITING
-#			spawn_timer = 0
-#		else:
-#			spawn_timer -= delta
-#	if spawn_state == State.WAITING:
-#		if enemy_node.get_child_count() == 0:
-#			spawn_state = State.COUNTING
-#			wave_timer = wave_interval
-#	if spawn_state == State.COUNTING:
-#		wave_timer -= delta
-#		if wave_timer <= 0:
-#			spawn_state = State.SPAWNING
-#			current_wave += 1
-#			generate_wave()
-#			spawn_timer = spawn_interval
+			get_tree().change_scene("res://TowerDefense/_Scenes/Win.tscn")
+	
 		
-		
-func spawn_enemy():
+func spawn_enemy() -> void:
 	var enemy = wave.pop_back().instance()
 	enemy_node.add_child(enemy)
 	enemy.global_transform.origin = global_transform.origin
 
 
-func generate_wave():
+func generate_wave() -> void:
 	wave_value = current_wave * value_multiplier
 	generate_enemies()
 	spawn_interval = wave_duration / wave.size()
 	
 
-func generate_enemies():
+func generate_enemies() -> void:
 	wave.clear()
 	while wave_value >= 1:
 		rng.randomize()
@@ -92,4 +72,3 @@ func generate_enemies():
 			wave.append(enemies[random_num])
 			wave_value -= enemy.spawn_cost
 		enemy.free()
-	print(wave)

--- a/TowerDefense/Scripts/enemySpawner.gd
+++ b/TowerDefense/Scripts/enemySpawner.gd
@@ -1,24 +1,95 @@
 extends Spatial
 
 export (Array, PackedScene) var enemies
-export var spawn_interval: float
-var spawning_timer:Timer
+export var value_multiplier: int
+export var max_wave: int
+export var wave_duration: float
+export var wave_interval: float
+enum State {SPAWNING, WAITING, COUNTING, WIN, LOSE}
+var current_wave: int = 0
+var wave_value: int
+
+var spawn_interval: float
+
+var wave: Array
+
+var spawn_timer: float
+var wave_timer: float = 0
 var rng = RandomNumberGenerator.new()
+var spawn_state = State.COUNTING
+
 
 onready var enemy_node = get_node("/root/Spatial/Enemies")
 
 
-func _ready():
-	spawning_timer = Timer.new()
-	add_child(spawning_timer)
-	spawning_timer.wait_time = spawn_interval
-	spawning_timer.connect("timeout", self, "instantiate_enemy")
-	spawning_timer.start()
-
-
-func instantiate_enemy():
-	rng.randomize()
-	var random_num = rng.randi_range(0, enemies.size()-1)
-	var enemy = enemies[random_num].instance()
+func _physics_process(delta):
+	match spawn_state:
+		State.SPAWNING:
+			if spawn_timer <= 0 and wave.size() > 0:
+				spawn_enemy()
+				spawn_timer = spawn_interval
+			elif wave.size() == 0:
+				spawn_state = State.WAITING
+				spawn_timer = 0
+			else:
+				spawn_timer -= delta
+		State.WAITING:
+			if enemy_node.get_child_count() == 0:
+				spawn_state = State.COUNTING
+				wave_timer = wave_interval
+				if current_wave >= max_wave:
+					spawn_state = State.WIN
+		State.COUNTING:
+			wave_timer -= delta
+			if wave_timer <= 0:
+				spawn_state = State.SPAWNING
+				current_wave += 1
+				generate_wave()
+				spawn_timer = spawn_interval
+		State.WIN:
+			print("You won!")
+#	if spawn_state == State.SPAWNING:
+#		if spawn_timer <= 0 and wave.size() > 0:
+#			spawn_enemy()
+#		elif wave.size() == 0:
+#			spawn_state = State.WAITING
+#			spawn_timer = 0
+#		else:
+#			spawn_timer -= delta
+#	if spawn_state == State.WAITING:
+#		if enemy_node.get_child_count() == 0:
+#			spawn_state = State.COUNTING
+#			wave_timer = wave_interval
+#	if spawn_state == State.COUNTING:
+#		wave_timer -= delta
+#		if wave_timer <= 0:
+#			spawn_state = State.SPAWNING
+#			current_wave += 1
+#			generate_wave()
+#			spawn_timer = spawn_interval
+		
+		
+func spawn_enemy():
+	var enemy = wave.pop_back().instance()
 	enemy_node.add_child(enemy)
 	enemy.global_transform.origin = global_transform.origin
+
+
+func generate_wave():
+	wave_value = current_wave * value_multiplier
+	generate_enemies()
+	spawn_interval = wave_duration / wave.size()
+	
+
+func generate_enemies():
+	wave.clear()
+	while wave_value >= 1:
+		rng.randomize()
+		var random_num = rng.randi_range(0, enemies.size() - 1)
+		var enemy = enemies[random_num].instance()
+		enemy_node.add_child(enemy)
+		if enemy.spawn_cost <= wave_value:
+			wave.append(enemies[random_num])
+			wave_value -= enemy.spawn_cost
+		enemy.free()
+	print(wave)

--- a/TowerDefense/Scripts/gameState.gd
+++ b/TowerDefense/Scripts/gameState.gd
@@ -4,25 +4,29 @@ class_name GameState
 
 export var max_lives: int
 
-# This could probably be a bool but I wanted to make an enum.
 enum State {IDLE, STAGING}
-var current_state = State.IDLE
-var valid_placement: bool
 var currency: int = 1000
 var current_lives: int
+var current_state = State.IDLE
+var current_wave : int = 0
+var valid_placement: bool
 
 onready var coins : Label = get_node("../UI/Coins")
 onready var lives_UI : Label = get_node("../UI/Lives")
+onready var wave_UI : Label = get_node("../UI/WaveNumber")
 
 
 func _ready() -> void:
 	coins.text = "Coins: " + str(currency)
 	current_lives = max_lives
 	lives_UI.text = "Lives: " + str(current_lives)
-	
+	wave_UI.text = "Wave: " + str(current_wave)
+
+
 func pay_for_tower(var price: int) -> void:
 	currency -= price
 	coins.text = "Coins: " + str(currency)
+
 
 func get_currency() -> int:
 	return currency
@@ -32,10 +36,15 @@ func lose_lives(var damage: int) -> void:
 	current_lives -= damage
 	if current_lives <= 0:
 		current_lives = 0
-		# TODO: Go to loss screen
+		get_tree().change_scene("res://TowerDefense/_Scenes/Lose.tscn")
 	lives_UI.text = "Lives: " + str(current_lives)
 
 
 func add_currency(var reward: int) -> void:
 	currency += reward
 	coins.text = "Coins: " + str(currency)
+
+
+func set_wave(var new_wave: int) -> void:
+	current_wave = new_wave
+	wave_UI.text = "Wave: " + str(current_wave)

--- a/TowerDefense/Scripts/swivelTray.gd
+++ b/TowerDefense/Scripts/swivelTray.gd
@@ -5,7 +5,7 @@ export var angle_offset: float = -90
 onready var tower_controller: Tower = get_node("../../")
 
 
-func _physics_process(delta):
+func _physics_process(_delta) -> void:
 	if tower_controller.current_target != null and tower_controller.current_target.is_inside_tree():
 		var target_position = tower_controller.current_target.global_transform.origin
 		look_at(target_position, Vector3.UP)

--- a/TowerDefense/Scripts/swivelTray.gd
+++ b/TowerDefense/Scripts/swivelTray.gd
@@ -6,7 +6,7 @@ onready var tower_controller: Tower = get_node("../../")
 
 
 func _physics_process(delta):
-	if tower_controller.current_target != null:
+	if tower_controller.current_target != null and tower_controller.current_target.is_inside_tree():
 		var target_position = tower_controller.current_target.global_transform.origin
 		look_at(target_position, Vector3.UP)
 		var adjusted_angle = get_rotation_degrees() + Vector3(0, angle_offset, 0)

--- a/TowerDefense/Scripts/tower.gd
+++ b/TowerDefense/Scripts/tower.gd
@@ -7,29 +7,29 @@ export var damage: float
 export var level: int
 export var rate_of_fire: float
 
-var attack_timer:Timer
 enum Mode {FIRST, LAST, NEAREST, FARTHEST}
-var current_target
-var targeting_mode = Mode.FIRST
-var kill_count: int
+
+var attack_timer:Timer
 var can_attack: bool
+var current_target
+var kill_count: int
+var targeting_mode = Mode.FIRST
 
 onready var area = get_node("Area")
 onready var trigger_collider = get_node("Area/CollisionShape")
 
 
-func _ready():
+func _ready() -> void:
 	can_attack = true
 	attack_timer = Timer.new()
 	add_child(attack_timer)
 	attack_timer.wait_time = 1 / rate_of_fire
 	attack_timer.connect("timeout", self, "attack_timer_timeout")
 	attack_timer.start()
-	#trigger_collider.set_scale(Vector3(range_radius, trigger_collider.get_scale().y, range_radius))
 	trigger_collider.shape.set_radius(range_radius)
-	
 
-func _physics_process(delta):
+
+func _physics_process(_delta) -> void:
 	target_enemy()
 	if current_target != null and can_attack:
 		attack_enemy()
@@ -45,10 +45,10 @@ func target_enemy() -> void:
 			current_target = null
 
 
-func attack_timer_timeout():
+func attack_timer_timeout() -> void:
 	can_attack = true
 	attack_timer.stop()
-	
+
 
 func attack_enemy() -> void:
 	can_attack = false

--- a/TowerDefense/Scripts/tower.gd
+++ b/TowerDefense/Scripts/tower.gd
@@ -55,10 +55,4 @@ func attack_enemy() -> void:
 	attack_timer.wait_time = 1 / rate_of_fire
 	attack_timer.start()
 	var enemy_manager = current_target.get_node("../")
-	enemy_manager.take_damage(damage)
-	if enemy_manager.get_current_health() <= 0:
-		current_target = null
-		enemy_manager.gs.add_currency(enemy_manager.reward)
-		kill_count += 1
-		enemy_manager.queue_free() 
-
+	enemy_manager.take_damage(self, damage)

--- a/TowerDefense/Scripts/towerBasic.gd
+++ b/TowerDefense/Scripts/towerBasic.gd
@@ -6,4 +6,3 @@ extends Tower
 
 #func target_enemy() -> void:
 #	print("test")
-

--- a/TowerDefense/Scripts/towerStaging.gd
+++ b/TowerDefense/Scripts/towerStaging.gd
@@ -1,32 +1,31 @@
 extends Spatial
+
 class_name TowerStaging
 
 export (PackedScene) var tower
 export var price: int
 
-var ray_origin = Vector3()
 var ray_end = Vector3()
+var ray_origin = Vector3()
 
 onready var camera: Camera = get_node("../Camera")
 onready var gs: GameState = get_node("/root/Spatial/GameState")
 onready var spatial = get_node("/root/Spatial")
 
 
-func _physics_process(delta):
+func _physics_process(_delta) -> void:
 	var space_state = get_world().direct_space_state
 	var mouse_position = get_viewport().get_mouse_position()
 	ray_origin = camera.project_ray_origin(mouse_position)
 	ray_end = ray_origin + camera.project_ray_normal(mouse_position) * 2000
-	var arr: Array
-	var intersection = space_state.intersect_ray(ray_origin, ray_end, arr, 1)
-	
+	var intersection = space_state.intersect_ray(ray_origin, ray_end, [self], 1)
+
 	if not intersection.empty():
 		var pos = intersection.position
 		global_transform.origin = pos
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	# Prevents errors when other keys are pressed.
 	if event is InputEventMouse:
 		if event.is_pressed():
 			if event.button_index == BUTTON_LEFT and gs.valid_placement:

--- a/TowerDefense/Scripts/validityCheck.gd
+++ b/TowerDefense/Scripts/validityCheck.gd
@@ -11,23 +11,18 @@ onready var gs: GameState = get_node("/root/Spatial/GameState")
 
 func _ready():
 	connect("body_entered", self, "collision_detection")
-	
-# Make sure the group goes on the rigidbody of things that have rbs.
-func collision_detection(body):
+
+
+func collision_detection(body) -> void:
 	if body.is_in_group("not_valid"):
 		change_all_meshes(invalid_material)
 		gs.valid_placement = false
 	else:
 		change_all_meshes(valid_material)
 		gs.valid_placement = true
-		
 
-func change_all_meshes(var material: Material):
-	var parent = get_parent()
+
+func change_all_meshes(var material: Material) -> void:
 	meshes = get_tree().get_nodes_in_group("mesh")
 	for mesh in meshes:
 		mesh.material_override = material
-
-# Get the parent node (Turret_Basic)
-# Get all MeshInstance children and add them to a list
-# Change the material on each child to a certain material

--- a/TowerDefense/_Scenes/ErickTest.tscn
+++ b/TowerDefense/_Scenes/ErickTest.tscn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:afc63a56aee759adf1b87826421b7ccc933a69917c786c956ad1b8f29167384b
-size 10871
+oid sha256:b487b5e07c1473b9edd4aaff03b74e030bd095bc0f49565b2b9fd02349d41686
+size 10927

--- a/TowerDefense/_Scenes/ErickTest.tscn
+++ b/TowerDefense/_Scenes/ErickTest.tscn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b487b5e07c1473b9edd4aaff03b74e030bd095bc0f49565b2b9fd02349d41686
-size 10927
+oid sha256:4d0df1d630921b9985d4552c5011cd1f9476fca4fad15bd65098d6dcea89bfbe
+size 11099

--- a/TowerDefense/_Scenes/Lose.tscn
+++ b/TowerDefense/_Scenes/Lose.tscn
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6b3b41c16932cfe13409298e1f09e2d123f1759067c846c13cc662082d140e4
+size 819

--- a/TowerDefense/_Scenes/Win.tscn
+++ b/TowerDefense/_Scenes/Win.tscn
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33ee2b31be1692876f6ed68b7ecdeca5824a5043976050094e8a26e3f4877260
+size 804

--- a/project.godot
+++ b/project.godot
@@ -9,6 +9,11 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "KinematicBody",
+"class": "EnemyManager",
+"language": "GDScript",
+"path": "res://TowerDefense/Scripts/enemyManager.gd"
+}, {
 "base": "Node",
 "class": "GameState",
 "language": "GDScript",
@@ -30,6 +35,7 @@ _global_script_classes=[ {
 "path": "res://TowerDefense/Scripts/towerStaging.gd"
 } ]
 _global_script_class_icons={
+"EnemyManager": "",
 "GameState": "",
 "GitAPI": "",
 "Tower": "",


### PR DESCRIPTION
resolves #38 
- each enemy type has a different cost and the enemy spawner randomly fills a list of enemies to spawn after starting with an amount to "buy" enemies
- the amount the enemy spawner has goes up linearly every wave
- the wave duration is constant and therefore spawns enemies faster and faster the later the wave
- Spawner has a FSM to go between spawning, waiting, counting, winning, and losing
- Attempted to fix a bug where towers would return an error if targeting an enemy as they reach the end as well as adding currency for multiple towers. More testing is needed to confirm.